### PR TITLE
Retry downloading hash file

### DIFF
--- a/jdownload-manager/pom.xml
+++ b/jdownload-manager/pom.xml
@@ -52,7 +52,7 @@
     <dependency> 
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.2-SNAPSHOT3</version>
+      <version>1.1.7</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/jdownload-manager/src/main/java/org/apodhrad/jdownload/manager/JDownloadManagerException.java
+++ b/jdownload-manager/src/main/java/org/apodhrad/jdownload/manager/JDownloadManagerException.java
@@ -1,0 +1,21 @@
+package org.apodhrad.jdownload.manager;
+
+/**
+ * JDownload Manager Exception
+ * 
+ * @author apodhrad
+ *
+ */
+public class JDownloadManagerException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public JDownloadManagerException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public JDownloadManagerException(String message) {
+		super(message);
+	}
+
+}

--- a/jdownload-manager/src/main/java/org/apodhrad/jdownload/manager/hash/URLHash.java
+++ b/jdownload-manager/src/main/java/org/apodhrad/jdownload/manager/hash/URLHash.java
@@ -4,9 +4,10 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.MessageDigest;
+
+import org.apodhrad.jdownload.manager.JDownloadManagerException;
 
 /**
  * URL hash implementation.
@@ -16,10 +17,12 @@ import java.security.MessageDigest;
  */
 public class URLHash extends Hash {
 
+	public static final int NUMBER_OF_RETRIES = 5;
+
 	private Hash hash;
 
 	public URLHash(String url) {
-		super(getHashSumFromUrl(url));
+		super(getHashSumFromUrl(url, NUMBER_OF_RETRIES));
 		if (url.toLowerCase().endsWith("md5")) {
 			hash = new MD5Hash(sum);
 		} else if (url.toLowerCase().endsWith("sha1")) {
@@ -31,16 +34,32 @@ public class URLHash extends Hash {
 		}
 	}
 
+	private static String getHashSumFromUrl(String url, int numberOfRetries) {
+		JDownloadManagerException exception = null;
+		String sum = null;
+		int count = 0;
+		while (sum == null) {
+			if (count++ > numberOfRetries) {
+				throw new JDownloadManagerException(
+						"Cannot get hash sum from " + url + " after " + numberOfRetries + " retries", exception);
+			}
+			try {
+				sum = getHashSumFromUrl(url);
+			} catch (JDownloadManagerException e) {
+				exception = e;
+			}
+		}
+		return sum;
+	}
+
 	private static String getHashSumFromUrl(String url) {
 		BufferedReader in = null;
 		String sum = null;
 		try {
 			in = new BufferedReader(new InputStreamReader(new URL(url).openStream()));
 			sum = in.readLine();
-		} catch (MalformedURLException e) {
-			throw new IllegalArgumentException("Cannot get hash sum from " + url, e);
-		} catch (IOException e) {
-			throw new IllegalArgumentException("Cannot get hash sum from " + url, e);
+		} catch (IOException ioe) {
+			throw new JDownloadManagerException("Cannot get hash sum from " + url, ioe);
 		} finally {
 			if (in != null) {
 				try {
@@ -71,10 +90,6 @@ public class URLHash extends Hash {
 	@Override
 	public String toString() {
 		return hash.toString();
-	}
-
-	public static void main(String[] args) throws Exception {
-		new URL("asf56g7df68g7s7g");
 	}
 
 }

--- a/jdownload-manager/src/test/java/org/apodhrad/jdownload/manager/HashTest.java
+++ b/jdownload-manager/src/test/java/org/apodhrad/jdownload/manager/HashTest.java
@@ -5,7 +5,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.MalformedURLException;
 
 import org.apodhrad.jdownload.manager.hash.MD5Hash;
 import org.apodhrad.jdownload.manager.hash.NullHash;
@@ -92,18 +94,20 @@ public class HashTest {
 		File hashFile = new File(JETTY_RESOURCE_BASE, TEST_RESOURCE + ".md5");
 		try {
 			new URLHash("fil://" + hashFile.getAbsolutePath());
-		} catch (IllegalArgumentException e) {
+		} catch (JDownloadManagerException e) {
+			assertTrue("Expected MalformedURLException", e.getCause() instanceof MalformedURLException);
 			return;
 		}
 		fail("Malformed URL wasn't detected");
 	}
-	
+
 	@Test
 	public void urlUnexistingHashTest() throws IOException {
 		File hashFile = new File(JETTY_RESOURCE_BASE, TEST_RESOURCE + ".foo");
 		try {
 			new URLHash("file://" + hashFile.getAbsolutePath());
-		} catch (IllegalArgumentException e) {
+		} catch (JDownloadManagerException e) {
+			assertTrue("Expected FileNotFoundException", e.getCause() instanceof FileNotFoundException);
 			return;
 		}
 		fail("Nonexisting URL wasn't detected");

--- a/jdownload-maven-plugin/pom.xml
+++ b/jdownload-maven-plugin/pom.xml
@@ -68,7 +68,7 @@
     <dependency> 
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.2-SNAPSHOT3</version>
+      <version>1.1.7</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
java.lang.IllegalArgumentException: Cannot get hash sum from https://repository.jboss.org/nexus/content/groups/public/org/jboss/tools/installation-tests/scripts/4.3.1-SNAPSHOT/scripts-4.3.1-20160127.235309-1-delivery.zip.sha1
	at java.net.SocketInputStream.read(SocketInputStream.java:209)
	at java.net.SocketInputStream.read(SocketInputStream.java:141)
	at sun.security.ssl.InputRecord.readFully(InputRecord.java:465)
	at sun.security.ssl.InputRecord.read(InputRecord.java:503)
	at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:973)
	at sun.security.ssl.SSLSocketImpl.performInitialHandshake(SSLSocketImpl.java:1375)
	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1403)
	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1387)
	at sun.net.www.protocol.https.HttpsClient.afterConnect(HttpsClient.java:563)
	at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:185)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1512)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1440)
	at sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:254)
	at java.net.URL.openStream(URL.java:1038)
	at org.apodhrad.jdownload.manager.hash.URLHash.getHashSumFromUrl(URLHash.java:38)
	at org.apodhrad.jdownload.manager.hash.URLHash.<init>(URLHash.java:22)
	at com.redhat.jbossqe.jbdsis.installer.test.Assert.getTestInstallationScript(Assert.java:77)
	at com.redhat.jbossqe.jbdsis.installer.test.Assert.assertUpdateSiteInstallation(Assert.java:55)
	at com.redhat.jbossqe.jbdsis.installer.test.Assert.assertUpdateSiteInstallation(Assert.java:44)
	at com.redhat.jbossqe.jbdsis.installer.test.JBDSCentralInstallationTest.centralIntallationTest(JBDSCentralInstallationTest.java:93)